### PR TITLE
Copy over auto-tagging functionality from sbt-guardrail

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,45 @@
+name: Tag release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8' ]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: print Java version
+      run: java -version
+    - uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Guess next version based on the library version
+      id: guessversion
+      run: |
+        source scripts/next-version.sh
+        echo "::set-output name=exists::${exists}"
+        echo "VERSION=${version}" >> $GITHUB_ENV
+    - name: Publish release notes
+      if: steps.guessversion.outputs.exists == 0
+      uses: release-drafter/release-drafter@v5
+      with:
+        publish: true
+        name: "v${{ env.VERSION }}"
+        tag: "v${{ env.VERSION }}"
+        version: "v${{ env.VERSION }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,17 @@
+# next-version.sh
+#   Guess the next version of the sbt-guardrail plugin based on the current library dependency
+#   Ideally, this'll let actions automatically tag and release.
+#
+#   Strategy is to pull the com.twilio %% guardrail % <VERSION>,
+#   ... check to see if a tag with that version exists,
+#   ... if so, exit 1
+#   ... if not, emit that version to stdout
+
+# Extract library version
+version="$(grep -ho 'com.twilio:guardrail_2.12:[^"]*"' build.gradle | grep -ho '\<\([0-9]\+\)\(\.[0-9]\+\)\{1,\}')"
+
+exists=0
+# Check to see if we've already released for this library version
+if git rev-parse "v${version}" >/dev/null 2>&1; then
+  exists=1
+fi


### PR DESCRIPTION
Adds a workflow that automatically creates a tag like `v${MAJOR}.${MINOR}.${PATCH}` based on the semver version of the guardrail core library, as depended on in `build.gradle`.

This will automatically release and tag when PRs like #33 are merged to master, opening the opportunity for automatic CI/CD like https://github.com/twilio/sbt-guardrail/pull/84.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
