### PR TITLE
Wire source generation into build

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ guardrail {
 }
 
 compileJava.dependsOn guardrail.petstore.gen
-sourceSets.main.java.srcDir guardrail.petstore.gen.outputDir
+
+// Include the generated sources as part of the build
+// Feel free to delete the one that does not apply to your project
+sourceSets.main.scala.srcDirs += new File(buildDir, 'guardrail-sources/scala')
+sourceSets.main.java.srcDirs  += new File(buildDir, 'guardrail-sources/java')
 ```
 
 Specs
@@ -72,7 +76,6 @@ guardrail {                                         // plugin declaration
     }
 
 }
-
 ```
 
 Available frameworks

--- a/src/functionalTest/groovy/com/twilio/guardrail/GuardrailGradlePluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/twilio/guardrail/GuardrailGradlePluginFunctionalTest.groovy
@@ -64,8 +64,8 @@ guardrail {
         !result.output.contains("Error")
 
         [
-            file('functionalTest/build/guardrail-petstoreClient'),
-            file('functionalTest/build/guardrail-petstoreServer')
+            file('functionalTest/build/guardrail-sources/scala/com/foobar/generated/petstore/client/pets'),
+            file('functionalTest/build/guardrail-sources/java/com/foobar/generated/petstore/server/pet')
         ].each {
             it.exists()
             it.directorySize() > 0

--- a/src/main/groovy/com/twilio/guardrail/GuardrailGen.groovy
+++ b/src/main/groovy/com/twilio/guardrail/GuardrailGen.groovy
@@ -15,6 +15,7 @@ class GuardrailGen extends DefaultTask {
 
     @OutputDirectory
     File outputDir
+    private File defaultOutputDir = null
 
     @Input
     @Optional
@@ -55,6 +56,7 @@ class GuardrailGen extends DefaultTask {
 
     GuardrailGen() {
         outputDir = new File(project.buildDir, 'guardrail-sources')
+        defaultOutputDir = outputDir
     }
 
     @TaskAction
@@ -67,7 +69,12 @@ class GuardrailGen extends DefaultTask {
 
         args << "--$kind"
         args << '--specPath' << inputFile.path
-        args << '--outputPath' << outputDir.path
+        // Why do builds need to be able to override this?
+        if (outputDir != defaultOutputDir) {
+            args << '--outputPath' << outputDir.path
+        } else {
+            args << '--outputPath' << new File(outputDir, language).path
+        }
         args << '--packageName' << packageName
 
         if (tracing) {

--- a/src/main/groovy/com/twilio/guardrail/GuardrailGen.groovy
+++ b/src/main/groovy/com/twilio/guardrail/GuardrailGen.groovy
@@ -57,27 +57,6 @@ class GuardrailGen extends DefaultTask {
         outputDir = new File(project.buildDir, 'guardrail-sources')
     }
 
-    /**
-     * Examples:
-     *   Generate a client, put it in src/main/scala under the com.twilio.messaging.console.clients package, with
-     *   OpenTracing support:
-     *     guardrail --specPath client-specs/account-events-api.json --outputPath src/main/scala --packageName com
-     *     .twilio.messaging.console.clients --tracing
-     *
-     *   Generate two clients, put both in src/main/scala, under different packages, one with tracing, one without:
-     *     guardrail \\
-     *       --client --specPath client-specs/account-events-api.json --outputPath src/main/scala --packageName com
-     *       .twilio.messaging.console.clients.events \\
-     *       --client --specPath client-specs/account-service.json --outputPath src/main/scala --packageName com
-     *       .twilio.messaging.console.clients.account --tracing
-     *
-     *   Generate client and server routes for the same specification:
-     *     guardrail \\
-     *       --client --specPath client-specs/account-events-api.json --outputPath src/main/scala --packageName com
-     *       .twilio.messaging.console.clients.events \\
-     *       --server --specPath client-specs/account-events-api.json --outputPath src/main/scala --packageName com
-     *       .twilio.messaging.console.clients.events
-     */
     @TaskAction
     void exec() {
         def args = []

--- a/src/main/groovy/com/twilio/guardrail/GuardrailGradlePlugin.groovy
+++ b/src/main/groovy/com/twilio/guardrail/GuardrailGradlePlugin.groovy
@@ -19,8 +19,6 @@ class GuardrailGradlePlugin implements Plugin<Project> {
             guardrail.gen = createGuardrailGen(project, guardrail.name)
 
             project.tasks.guardrail.dependsOn(guardrail.gen)
-
-            guardrail.gen.outputDir = new File(project.buildDir, "guardrail-${guardrail.name}")
         }
     }
 


### PR DESCRIPTION
Include `language` into generated source path, to make it easier to wire sources into build

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
